### PR TITLE
Use x/sys/unix.Sysconf on solaris

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/tklauser/numcpus v0.2.0
-	golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc
+	golang.org/x/sys v0.0.0-20210217105451-b926d437f341
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/tklauser/numcpus v0.2.0 h1:Y+tTPBtO2xyXRQKX1XUYjZu4jbNzvDugwDIz4EYSpB4=
 github.com/tklauser/numcpus v0.2.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl8miYgd5k=
-golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc h1:y0Og6AYdwus7SIAnKnDxjc4gJetRiYEWOx4AKbOeyEI=
 golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210217105451-b926d437f341 h1:2/QtM1mL37YmcsT8HaDNHDgTqqFVw+zr8UzMiBVLzYU=
+golang.org/x/sys v0.0.0-20210217105451-b926d437f341/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/sysconf_solaris.go
+++ b/sysconf_solaris.go
@@ -4,25 +4,8 @@
 
 package sysconf
 
-import (
-	"syscall"
-	"unsafe"
-)
-
-// TODO: remove sysconf wrapper once https://golang.org/cl/286593 is merged and x/sys updated.
-
-//go:cgo_import_dynamic libc_sysconf sysconf "libc.so"
-//go:linkname procSysconf libc_sysconf
-
-var procSysconf uintptr
-
-//go:linkname sysvicall6 syscall.sysvicall6
-func sysvicall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
+import "golang.org/x/sys/unix"
 
 func sysconf(name int) (int64, error) {
-	n, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procSysconf)), 1, uintptr(name), 0, 0, 0, 0, 0)
-	if errno != 0 {
-		return -1, errInvalid
-	}
-	return int64(n), nil
+	return unix.Sysconf(name)
 }


### PR DESCRIPTION
Update golang.org/x/sys/unix now that https://golang.org/cl/286593 was
merged and use unix.Sysconf on solaris instead of manually implementing
the wrapper.