### PR TITLE
.github/workflows: drop Ubuntu 16.04 from runners

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,10 +3,10 @@ name: Static Analysis
 on:
   push:
     branches:
-      - master
+    - master
   pull_request:
     branches:
-      - master
+    - master
 
 jobs:
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.15, 1.16, 1.17]
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
These are no longer supported, see
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources