### PR TITLE
.github/workflows: update actions/setup-go to v3

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.17'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,15 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: [ '1.15' , '1.16', '1.17', '1.18.0-rc1' ]
+        go-version: [ '1.15' , '1.16', '1.17', '1.18.0-rc.1' ]
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-        stable: false
 
     - name: Check out code
       uses: actions/checkout@v2


### PR DESCRIPTION
Release notes: https://github.com/actions/setup-go/releases/tag/v3.0.0

This allows to drop the `stable` input.