### PR TITLE
.github/workflows: test on ubuntu-22.04 and macos-12 beta runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ '1.16', '1.17', '1.18' ]
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources