### PR TITLE
Update minimum supported Go version to 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: ['1.19', '1.20', '1.21']
+        # Oldest supported version is 1.18, plus the latest two releases.
+        go-version: ['1.18', '1.20', '1.21']
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tklauser/go-sysconf
 
-go 1.13
+go 1.18
 
 require (
 	github.com/tklauser/numcpus v0.6.1

--- a/mksysconf.go
+++ b/mksysconf.go
@@ -10,7 +10,6 @@ package main
 import (
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -51,7 +50,7 @@ func gensysconf(in, out, goos, goarch string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(out, b, 0644)
+	return os.WriteFile(out, b, 0644)
 }
 
 func main() {

--- a/sysconf_linux.go
+++ b/sysconf_linux.go
@@ -98,6 +98,9 @@ func getNprocsProcStat() (int64, error) {
 			break
 		}
 	}
+	if err := s.Err(); err != nil {
+		return -1, err
+	}
 	return count, nil
 }
 

--- a/sysconf_linux.go
+++ b/sysconf_linux.go
@@ -6,7 +6,6 @@ package sysconf
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -26,7 +25,7 @@ const (
 )
 
 func readProcFsInt64(path string, fallback int64) int64 {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return fallback
 	}

--- a/sysconf_linux.go
+++ b/sysconf_linux.go
@@ -86,10 +86,16 @@ func getNprocsProcStat() (int64, error) {
 	s := bufio.NewScanner(f)
 	for s.Scan() {
 		if line := strings.TrimSpace(s.Text()); strings.HasPrefix(line, "cpu") {
-			l := strings.SplitN(line, " ", 2)
-			_, err := strconv.ParseInt(l[0][3:], 10, 64)
-			if err == nil {
-				count++
+			cpu, _, found := strings.Cut(line, " ")
+			if found {
+				// skip first line with accumulated values
+				if cpu == "cpu" {
+					continue
+				}
+				_, err := strconv.ParseInt(cpu[len("cpu"):], 10, 64)
+				if err == nil {
+					count++
+				}
 			}
 		} else {
 			// The current format of /proc/stat has all the

--- a/sysconf_netbsd.go
+++ b/sysconf_netbsd.go
@@ -25,10 +25,10 @@ const (
 	_POSIX2_UPE       = -1
 )
 
-var (
-	clktck     int64
-	clktckOnce sync.Once
-)
+var clktck struct {
+	sync.Once
+	v int64
+}
 
 func sysconfPOSIX(name int) (int64, error) {
 	// NetBSD does not define all _POSIX_* values used in sysconf_posix.go
@@ -42,7 +42,6 @@ func sysconf(name int) (int64, error) {
 	// Duplicate the relevant values here.
 
 	switch name {
-
 	// 1003.1
 	case SC_ARG_MAX:
 		return sysctl32("kern.argmax"), nil
@@ -55,13 +54,14 @@ func sysconf(name int) (int64, error) {
 		}
 		return -1, nil
 	case SC_CLK_TCK:
-		clktckOnce.Do(func() {
-			clktck = -1
+		// TODO: use sync.OnceValue once Go 1.21 is the minimal supported version
+		clktck.Do(func() {
+			clktck.v = -1
 			if ci, err := unix.SysctlClockinfo("kern.clockrate"); err == nil {
-				clktck = int64(ci.Hz)
+				clktck.v = int64(ci.Hz)
 			}
 		})
-		return clktck, nil
+		return clktck.v, nil
 	case SC_NGROUPS_MAX:
 		return sysctl32("kern.ngroups"), nil
 	case SC_JOB_CONTROL:


### PR DESCRIPTION
...and some small drive-by fixes and refactoring.