### PR TITLE
Remove unnecessary +build tags

### DIFF
--- a/cgotest/sysconf_cgotest.go
+++ b/cgotest/sysconf_cgotest.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package sysconf_cgotest
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package sysconf_test
 

--- a/mksysconf.go
+++ b/mksysconf.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 
@@ -33,16 +32,14 @@ func gensysconf(in, out, goos, goarch string) error {
 		return err
 	}
 
-	goBuild, build := goos, goos
+	goBuild := goos
 	if goarch != "" {
 		goBuild = fmt.Sprintf("%s && %s", goos, goarch)
-		build = fmt.Sprintf("%s,%s", goos, goarch)
 	}
 
 	r := fmt.Sprintf(`$1
 
-//go:build %s
-// +build %s`, goBuild, build)
+//go:build %s`, goBuild)
 	cgoCommandRegex := regexp.MustCompile(`(cgo -godefs .*)`)
 	b = cgoCommandRegex.ReplaceAll(b, []byte(r))
 

--- a/sysconf_bsd.go
+++ b/sysconf_bsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || netbsd || openbsd
-// +build darwin dragonfly freebsd netbsd openbsd
 
 package sysconf
 

--- a/sysconf_defs_darwin.go
+++ b/sysconf_defs_darwin.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_defs_dragonfly.go
+++ b/sysconf_defs_dragonfly.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_defs_freebsd.go
+++ b/sysconf_defs_freebsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_defs_linux.go
+++ b/sysconf_defs_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_defs_netbsd.go
+++ b/sysconf_defs_netbsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_defs_openbsd.go
+++ b/sysconf_defs_openbsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_defs_solaris.go
+++ b/sysconf_defs_solaris.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_generic.go
+++ b/sysconf_generic.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
 
 package sysconf
 

--- a/sysconf_posix.go
+++ b/sysconf_posix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || openbsd
-// +build darwin dragonfly freebsd linux openbsd
 
 package sysconf
 

--- a/sysconf_test.go
+++ b/sysconf_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package sysconf_test
 

--- a/sysconf_unsupported.go
+++ b/sysconf_unsupported.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
-// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package sysconf
 

--- a/sysconf_values_freebsd.go
+++ b/sysconf_values_freebsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_values_linux.go
+++ b/sysconf_values_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/sysconf_values_netbsd.go
+++ b/sysconf_values_netbsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package sysconf
 

--- a/zsysconf_defs_darwin.go
+++ b/zsysconf_defs_darwin.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_defs_darwin.go
 
 //go:build darwin
-// +build darwin
 
 package sysconf
 

--- a/zsysconf_defs_dragonfly.go
+++ b/zsysconf_defs_dragonfly.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_defs_dragonfly.go
 
 //go:build dragonfly
-// +build dragonfly
 
 package sysconf
 

--- a/zsysconf_defs_freebsd.go
+++ b/zsysconf_defs_freebsd.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_defs_freebsd.go
 
 //go:build freebsd
-// +build freebsd
 
 package sysconf
 

--- a/zsysconf_defs_linux.go
+++ b/zsysconf_defs_linux.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_defs_linux.go
 
 //go:build linux
-// +build linux
 
 package sysconf
 

--- a/zsysconf_defs_netbsd.go
+++ b/zsysconf_defs_netbsd.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_defs_netbsd.go
 
 //go:build netbsd
-// +build netbsd
 
 package sysconf
 

--- a/zsysconf_defs_openbsd.go
+++ b/zsysconf_defs_openbsd.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_defs_openbsd.go
 
 //go:build openbsd
-// +build openbsd
 
 package sysconf
 

--- a/zsysconf_defs_solaris.go
+++ b/zsysconf_defs_solaris.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_defs_solaris.go
 
 //go:build solaris
-// +build solaris
 
 package sysconf
 

--- a/zsysconf_values_freebsd_386.go
+++ b/zsysconf_values_freebsd_386.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_freebsd.go
 
 //go:build freebsd && 386
-// +build freebsd,386
 
 package sysconf
 

--- a/zsysconf_values_freebsd_amd64.go
+++ b/zsysconf_values_freebsd_amd64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_freebsd.go
 
 //go:build freebsd && amd64
-// +build freebsd,amd64
 
 package sysconf
 

--- a/zsysconf_values_freebsd_arm.go
+++ b/zsysconf_values_freebsd_arm.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_freebsd.go
 
 //go:build freebsd && arm
-// +build freebsd,arm
 
 package sysconf
 

--- a/zsysconf_values_freebsd_arm64.go
+++ b/zsysconf_values_freebsd_arm64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_freebsd.go
 
 //go:build freebsd && arm64
-// +build freebsd,arm64
 
 package sysconf
 

--- a/zsysconf_values_freebsd_riscv64.go
+++ b/zsysconf_values_freebsd_riscv64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_freebsd.go
 
 //go:build freebsd && riscv64
-// +build freebsd,riscv64
 
 package sysconf
 

--- a/zsysconf_values_linux_386.go
+++ b/zsysconf_values_linux_386.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && 386
-// +build linux,386
 
 package sysconf
 

--- a/zsysconf_values_linux_amd64.go
+++ b/zsysconf_values_linux_amd64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && amd64
-// +build linux,amd64
 
 package sysconf
 

--- a/zsysconf_values_linux_arm.go
+++ b/zsysconf_values_linux_arm.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && arm
-// +build linux,arm
 
 package sysconf
 

--- a/zsysconf_values_linux_arm64.go
+++ b/zsysconf_values_linux_arm64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && arm64
-// +build linux,arm64
 
 package sysconf
 

--- a/zsysconf_values_linux_loong64.go
+++ b/zsysconf_values_linux_loong64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && loong64
-// +build linux,loong64
 
 package sysconf
 

--- a/zsysconf_values_linux_mips.go
+++ b/zsysconf_values_linux_mips.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && mips
-// +build linux,mips
 
 package sysconf
 

--- a/zsysconf_values_linux_mips64.go
+++ b/zsysconf_values_linux_mips64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && mips64
-// +build linux,mips64
 
 package sysconf
 

--- a/zsysconf_values_linux_mips64le.go
+++ b/zsysconf_values_linux_mips64le.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && mips64le
-// +build linux,mips64le
 
 package sysconf
 

--- a/zsysconf_values_linux_mipsle.go
+++ b/zsysconf_values_linux_mipsle.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && mipsle
-// +build linux,mipsle
 
 package sysconf
 

--- a/zsysconf_values_linux_ppc64.go
+++ b/zsysconf_values_linux_ppc64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && ppc64
-// +build linux,ppc64
 
 package sysconf
 

--- a/zsysconf_values_linux_ppc64le.go
+++ b/zsysconf_values_linux_ppc64le.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && ppc64le
-// +build linux,ppc64le
 
 package sysconf
 

--- a/zsysconf_values_linux_riscv64.go
+++ b/zsysconf_values_linux_riscv64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && riscv64
-// +build linux,riscv64
 
 package sysconf
 

--- a/zsysconf_values_linux_s390x.go
+++ b/zsysconf_values_linux_s390x.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_linux.go
 
 //go:build linux && s390x
-// +build linux,s390x
 
 package sysconf
 

--- a/zsysconf_values_netbsd_386.go
+++ b/zsysconf_values_netbsd_386.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_netbsd.go
 
 //go:build netbsd && 386
-// +build netbsd,386
 
 package sysconf
 

--- a/zsysconf_values_netbsd_amd64.go
+++ b/zsysconf_values_netbsd_amd64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_netbsd.go
 
 //go:build netbsd && amd64
-// +build netbsd,amd64
 
 package sysconf
 

--- a/zsysconf_values_netbsd_arm.go
+++ b/zsysconf_values_netbsd_arm.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_netbsd.go
 
 //go:build netbsd && arm
-// +build netbsd,arm
 
 package sysconf
 

--- a/zsysconf_values_netbsd_arm64.go
+++ b/zsysconf_values_netbsd_arm64.go
@@ -2,7 +2,6 @@
 // cgo -godefs sysconf_values_netbsd.go
 
 //go:build netbsd && arm64
-// +build netbsd,arm64
 
 package sysconf
 


### PR DESCRIPTION
The go:build tags are sufficient and the +build tags are no longer needed since switching to Go 1.18 in commit 73ea1b38cdbc ("go.mod: update to go 1.18").