### PR TITLE
.github/workflows: test on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # Oldest supported version is 1.18, plus the latest two releases.
         go-version: ['1.18', '1.21', '1.22']
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13, macos-14]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13, macos-14, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/cgotest/sysconf_cgotest_other.go
+++ b/cgotest/sysconf_cgotest_other.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Tobias Klauser. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package sysconf_cgotest
+
+import (
+	"runtime"
+	"testing"
+)
+
+func testSysconfCgoMatch(t *testing.T) {
+	t.Skipf("skipping cgotest on unsupported platform %s", runtime.GOOS)
+}


### PR DESCRIPTION
This covers unsupported platforms on which tests should still pass.