### PR TITLE
ci: drop unsupported macos-12 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # Oldest supported version is 1.18, plus the latest two releases.
         go-version: ['1.18', '1.22', '1.23']
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, macos-14, macos-15, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/10721