### PR TITLE
Fix SC_OPEN_MAX/SC_STREAM_MAX RLIM_INFINITY check

### DIFF
--- a/sysconf_darwin.go
+++ b/sysconf_darwin.go
@@ -86,7 +86,7 @@ func sysconf(name int) (int64, error) {
 		if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlim); err != nil {
 			return -1, nil
 		}
-		if rlim.Cur > unix.RLIM_INFINITY {
+		if rlim.Cur == unix.RLIM_INFINITY {
 			return -1, nil
 		}
 		if rlim.Cur > _LONG_MAX {


### PR DESCRIPTION
Compare rlim.Cur to unix.RLIM_INFINITY for equality.  The current check can never be true since RLIM_INFINITY is the maximum value of the type. This follows the implementation on FreeBSD which performs the same check for equality.