### PR TITLE
Consistently return -1 for `SC_PHYS_PAGES` on error

### DIFF
--- a/sysconf_darwin.go
+++ b/sysconf_darwin.go
@@ -296,7 +296,10 @@ func sysconf(name int) (int64, error) {
 		return _XOPEN_XCU_VERSION, nil
 
 	case SC_PHYS_PAGES:
-		return sysctl64("hw.memsize") / int64(unix.Getpagesize()), nil
+		if mem := sysctl64("hw.memsize"); mem >= 0 {
+			return mem / int64(unix.Getpagesize()), nil
+		}
+		return -1, nil
 	case SC_NPROCESSORS_CONF:
 		fallthrough
 	case SC_NPROCESSORS_ONLN:

--- a/sysconf_linux.go
+++ b/sysconf_linux.go
@@ -55,7 +55,7 @@ func getPhysPages() int64 {
 	var si unix.Sysinfo_t
 	err := unix.Sysinfo(&si)
 	if err != nil {
-		return int64(0)
+		return -1
 	}
 	return getMemPages(uint64(si.Totalram), si.Unit)
 }
@@ -64,7 +64,7 @@ func getAvPhysPages() int64 {
 	var si unix.Sysinfo_t
 	err := unix.Sysinfo(&si)
 	if err != nil {
-		return int64(0)
+		return -1
 	}
 	return getMemPages(uint64(si.Freeram), si.Unit)
 }

--- a/sysconf_netbsd.go
+++ b/sysconf_netbsd.go
@@ -195,7 +195,10 @@ func sysconf(name int) (int64, error) {
 
 	// Linux/Solaris
 	case SC_PHYS_PAGES:
-		return sysctl64("hw.physmem64") / int64(unix.Getpagesize()), nil
+		if mem := sysctl64("hw.physmem64"); mem >= 0 {
+			return mem / int64(unix.Getpagesize()), nil
+		}
+		return -1, nil
 
 	// Native
 	case SC_SCHED_RT_TS:

--- a/sysconf_openbsd.go
+++ b/sysconf_openbsd.go
@@ -257,7 +257,10 @@ func sysconf(name int) (int64, error) {
 		}
 		return -1, nil
 	case SC_PHYS_PAGES:
-		return sysctl64("hw.physmem") / int64(unix.Getpagesize()), nil
+		if mem := sysctl64("hw.physmem"); mem >= 0 {
+			return mem / int64(unix.Getpagesize()), nil
+		}
+		return -1, nil
 	case SC_NPROCESSORS_CONF:
 		return sysctl32("hw.ncpu"), nil
 	case SC_NPROCESSORS_ONLN:


### PR DESCRIPTION
This matches with other values where e.g. an error in the sysctl leads to -1 being returned. Note that the dragonfly implementation already does this.